### PR TITLE
Add StockMaster agent with Finnhub API tool

### DIFF
--- a/app/agent/stock_master.ts
+++ b/app/agent/stock_master.ts
@@ -1,0 +1,25 @@
+import { ToolCallAgent } from "./toolcall";
+import { ToolCollection } from "../tool/base";
+import { FinnhubAPI } from "../tool/finnhub";
+import { Terminate } from "../tool/terminate";
+import { SYSTEM_PROMPT, NEXT_STEP_PROMPT } from "../prompt/stock_master";
+
+/** StockMaster: an agent focused on intraday US stock trading guidance */
+export class StockMaster extends ToolCallAgent {
+  static SYSTEM_PROMPT: string = SYSTEM_PROMPT;
+  static NEXT_STEP_PROMPT: string = NEXT_STEP_PROMPT;
+
+  constructor(options: any = {}) {
+    super({
+      name: "StockMaster",
+      description: "US stock intraday momentum trading assistant",
+      system_prompt: StockMaster.SYSTEM_PROMPT,
+      next_step_prompt: StockMaster.NEXT_STEP_PROMPT,
+      max_steps: options.max_steps ?? 30
+    });
+    this["available_tools"] = new ToolCollection(
+      new FinnhubAPI(),
+      new Terminate()
+    );
+  }
+}

--- a/app/prompt/stock_master.ts
+++ b/app/prompt/stock_master.ts
@@ -1,0 +1,3 @@
+export const SYSTEM_PROMPT = `You are StockMaster, a master of intraday US stock momentum trading. You specialize in tracking a single stock's real-time data and providing precise buy and sell timing suggestions so the user can profit from quick trades. Use the provided tools to fetch market data and respond with actionable advice.`;
+
+export const NEXT_STEP_PROMPT = `Use the finnhub_api tool to query market data such as quotes or candles. Analyse short term trends and determine optimal intraday entry or exit points. When finished or when further user input is needed, use the terminate tool.`;

--- a/app/tool/finnhub.ts
+++ b/app/tool/finnhub.ts
@@ -1,0 +1,50 @@
+import { BaseTool, ToolError } from "./base";
+import fetch from "node-fetch";
+
+/**
+ * Generic tool to query the Finnhub API.
+ * Provide an API endpoint path and optional query parameters.
+ */
+export class FinnhubAPI extends BaseTool {
+  constructor() {
+    super(
+      "finnhub_api",
+      "Query the Finnhub stock market API using a specific endpoint and parameters.",
+      {
+        type: "object",
+        properties: {
+          endpoint: { type: "string", description: "(required) API endpoint, e.g. 'quote' or 'stock/candle'." },
+          params: { type: "object", description: "(optional) Query parameters for the endpoint (excluding token)." }
+        },
+        required: ["endpoint"],
+        additionalProperties: false
+      }
+    );
+  }
+
+  async execute(args: { endpoint: string; params?: Record<string, any> }): Promise<string> {
+    const { endpoint, params = {} } = args;
+    if (!endpoint) throw new ToolError("endpoint is required");
+    const apiKey = process.env.FINNHUB_API_KEY;
+    if (!apiKey) throw new ToolError("FINNHUB_API_KEY environment variable not set");
+
+    const url = new URL(`https://finnhub.io/api/v1/${endpoint}`);
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.append(k, String(v));
+    }
+    url.searchParams.append("token", apiKey);
+
+    try {
+      const res = await fetch(url.toString());
+      if (!res.ok) {
+        const text = await res.text();
+        throw new ToolError(`HTTP ${res.status}: ${text}`);
+      }
+      const data = await res.json();
+      return JSON.stringify(data);
+    } catch (e: any) {
+      if (e instanceof ToolError) throw e;
+      throw new ToolError(`Finnhub API request failed: ${e.message}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `FinnhubAPI` tool for accessing finnhub.io endpoints
- add new `StockMaster` agent specialized in intraday US stock trading
- include prompts for `StockMaster` agent

## Testing
- `npx tsc` *(fails: missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_6879d5c121748320aaa30c713d16f95f